### PR TITLE
Added reactor_redstone_port component

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Documentation is also ready for the following components:
 - me_controller
 - me_exportbus
 - me_interface
+- reactor_redstone_port
 - redstone
 - screen
 - tilechest

--- a/lua/components/ReactorRedstonePort.lua
+++ b/lua/components/ReactorRedstonePort.lua
@@ -1,0 +1,41 @@
+---@meta _
+
+
+---@class reactor_redstone_port: BaseComponent
+---@field type 'reactor_redstone_port'
+local reactorRP = {}
+
+---Get the reactor's emitted heat. Useful for fluid reactors.
+---@return integer
+function reactorRP.getEmitHeat() end
+
+---Get the reactor's heat.
+---@return integer
+function reactorRP.getHeat() end
+
+---Get the reactor's maximum heat before exploding.
+---@return integer
+function reactorRP.getMaxHeat() end
+
+---Get the reactor's energy output. Not multiplied with the base EU/t value.
+---@return integer
+function reactorRP.getReactorEnergyOutput() end
+
+---Get the reactor's base EU/t value.
+---@return integer
+function reactorRP.getReactorEUOutput() end
+
+---Get whether the reactor is active and supposed to produce energy.
+---@return boolean
+function reactorRP.producesEnergy() end
+
+---Get information about the item stored in the given reactor slot.
+---@param x integer # Item's position on the x axis
+---@param y integer # Item's position on the y axis
+---@return IReactorComponent
+function reactorRP.getSlotInfo(x, y) end
+
+---activate or deactivate the reactor
+---@param active boolean? # If not provided, toggles between.
+---@return boolean
+function reactorRP.setActive(active) end

--- a/lua/type_definitions/ic2_types/IReactorComponent.lua
+++ b/lua/type_definitions/ic2_types/IReactorComponent.lua
@@ -1,0 +1,7 @@
+---@meta _
+
+---@class IReactorComponent
+---@field maxHeat integer
+---@field item ItemStack
+---@field canStoreHeat boolean
+---@field heat integer


### PR DESCRIPTION
This merge request adds `reactor_redstone_port` component and related `IReactorComponent` type.

Reference: https://github.com/GTNewHorizons/OpenComputers/blob/master/src/main/scala/li/cil/oc/integration/ic2/DriverReactorRedstonePort.java