### PR TITLE
removed getEmitHeat from BaseReactor and move to reactor_redstone_port

### DIFF
--- a/lua/components/ReactorRedstonePort.lua
+++ b/lua/components/ReactorRedstonePort.lua
@@ -3,3 +3,7 @@
 ---@class reactor_redstone_port: BaseReactor
 ---@field type "reactor_redstone_port"
 local reactorRedstonePort = {}
+
+---Get the reactor's emitted heat. Useful for fluid reactors.
+---@return integer
+function reactorRedstonePort.getEmitHeat() end


### PR DESCRIPTION
`getEmitHeat` method only exists for fluid nukes, so it doesn't exists in base reactor.